### PR TITLE
fix opposite team

### DIFF
--- a/src/Match.js
+++ b/src/Match.js
@@ -67,10 +67,10 @@ export default class Match extends EventEmitter {
 
   getOppositeTeam(team) {
     if (this.homeTeam.getId() === team.IdTeam) {
-      return this.homeTeam;
+      return this.awayTeam;
     }
 
-    return this.awayTeam;
+    return this.homeTeam;
   }
 
   getForecasted() {


### PR DESCRIPTION
Si l'équipe donnée est la "home" il faut retourner l'away et inversement
=> permet d'être cohérent avec les tests